### PR TITLE
Click blank element after adding cohost

### DIFF
--- a/meeting-generation/meeting-generation.py
+++ b/meeting-generation/meeting-generation.py
@@ -107,7 +107,7 @@ def create_meeting(driver, email, topic, cohost, when, duration):
 
     # Registration
     css_checkbox(driver, "#option_registration", False)
-    
+
     # Meeting ID
     css_click(driver, "#optionOneTimeId")
 
@@ -136,6 +136,8 @@ def create_meeting(driver, email, topic, cohost, when, duration):
         try:
             WebDriverWait(driver, MAX_WAIT).until(EC.element_to_be_clickable((By.ID, "select-item-select-alter-0")))
             css_click(driver, "#select-item-select-alter-0")
+            WebDriverWait(driver, MAX_WAIT).until(EC.element_to_be_clickable((By.CSS_SELECTOR, '#schedule_form > div.meeting-options-section > div:nth-child(10) > div > label')))
+            css_click(driver,'#schedule_form > div.meeting-options-section > div:nth-child(10) > div > label')
         except Exception:
             print("COHOST ERR: " + email)
             # return "ERROR"
@@ -184,4 +186,3 @@ def run(input, output, topic, cohost, when, duration, browser):
 
 if __name__ == '__main__':
     run()
-


### PR DESCRIPTION
Ran into a "save error" when trying to add certain email addresses as alternative hosts that are similar to other emails in the berkeley organization. See here for an example (with emails removed for privacy):

![Screen Shot 2021-03-05 at 10 52 12 AM](https://user-images.githubusercontent.com/46937328/110161134-cc8e0c00-7da1-11eb-8e4c-3af3d166552c.png)

A (not very robust) fix is to have selenium click on a blank element before trying to click the save button (which is covered by this dropdown, resulting in the save error). 